### PR TITLE
Updating rendering scale factor to center on laptops

### DIFF
--- a/src/client/js/app.js
+++ b/src/client/js/app.js
@@ -831,8 +831,8 @@ export default class App {
     const tablet = 2;
     const desktop = 3;
     const tabletOrDesktop = this.width <= 1500 || this.height <= 870
-      ? desktop
-      : tablet;
+      ? tablet
+      : desktop;
 
     /**
      * These are raw scales, we can adjust

--- a/src/client/js/main.js
+++ b/src/client/js/main.js
@@ -91,6 +91,8 @@ export default class WTF {
       return false;
     });
 
+    window.onresize = this.app.resize.bind(this);
+
     resizeCheck.bind('transitionend', this.app.resize.bind(this));
     resizeCheck.bind('webkitTransitionEnd', this.app.resize.bind(this));
     resizeCheck.bind('oTransitionEnd', this.app.resize.bind(this));

--- a/src/client/js/renderer/renderer.js
+++ b/src/client/js/renderer/renderer.js
@@ -81,7 +81,7 @@ export default class Renderer {
 
     this.stopRendering = false;
     this.animateTiles = true;
-    this.debugging = false;
+    this.debugging = true;
     this.brightness = 100;
     this.drawNames = true;
     this.drawLevels = true;
@@ -110,6 +110,9 @@ export default class Renderer {
     this.scale = this.getScale();
     this.drawingScale = this.getDrawingScale();
 
+    console.log('camera scale', this.scale);
+    console.log('camera drawing scale', this.drawingScale);
+
     this.forEachContext((context) => {
       context.imageSmoothingEnabled = false; // eslint-disable-line
       context.webkitImageSmoothingEnabled = false; // eslint-disable-line
@@ -126,9 +129,8 @@ export default class Renderer {
       return;
     }
 
-    console.log('camera grid width');
+    console.log('camera grid widthxheight', this.camera.gridWidth, this.camera.gridHeight);
     console.log('camera tile size', this.tileSize);
-
 
     this.screenWidth = this.camera.gridWidth * this.tileSize;
     this.screenHeight = this.camera.gridHeight * this.tileSize;
@@ -1090,8 +1092,8 @@ export default class Renderer {
     this.textContext.clearRect(
       0,
       0,
-      this.textCanvas.width,
-      this.textCanvas.height,
+      this.textCanvas.width * this.scale,
+      this.textCanvas.height * this.scale,
     );
   }
 


### PR DESCRIPTION
Fix scale factor that is preventing the game tiles from centering properly on small laptops and turn on UI debugging by default for now. Also adds the resize callback to the window onresize event listener.